### PR TITLE
Disable DVC cloud versioning

### DIFF
--- a/.dvc/config
+++ b/.dvc/config
@@ -3,4 +3,4 @@
     remote = gcp-remla
 ['remote "gcp-remla"']
     url = gs://remla23-team18
-    version_aware = true
+    version_aware = false


### PR DESCRIPTION
When cloud versioning is enabled, we cannot use the `dvc.api.get_url`
function in `model-service` to downloads the models. See:
https://dvc.org/doc/user-guide/data-management/cloud-versioning\#expand-for-more-details-on-the-differences-between-cloud-versioned-and-content-addressable-storage
